### PR TITLE
Added new bing_linkedin_contacts module (@cam-barts)

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -1004,3 +1004,13 @@
   path: reporting/xml
   required_keys: []
   version: '1.1'
+- author: Cam Barts (@cam-barts)
+  dependencies: []
+  description: Harvests Basic Contact Information from Bing based on LinkedIn profiles
+  files: []
+  last_updated: '2019-07-19'
+  name: Bing LinkedIn Profile Contact Harvester
+  path: recon/profiles-contacts/bing_linkedin_contacts
+  required_keys:
+  - bing_api
+  version: '1.0'

--- a/modules.yml
+++ b/modules.yml
@@ -1006,9 +1006,9 @@
   version: '1.1'
 - author: Cam Barts (@cam-barts)
   dependencies: []
-  description: Harvests Basic Contact Information from Bing based on LinkedIn profiles
+  description: Harvests Basic Contact Information from Bing based on LinkedIn profiles.
   files: []
-  last_updated: '2019-07-19'
+  last_updated: '2019-07-24'
   name: Bing LinkedIn Profile Contact Harvester
   path: recon/profiles-contacts/bing_linkedin_contacts
   required_keys:

--- a/modules/recon/profiles-contacts/bing_linkedin_contacts.py
+++ b/modules/recon/profiles-contacts/bing_linkedin_contacts.py
@@ -1,0 +1,49 @@
+from recon.core.module import BaseModule
+from recon.mixins.search import BingAPIMixin
+
+
+class Module(BaseModule, BingAPIMixin):
+
+    meta = {
+        "name": "Bing LinkedIn Profile Contact Harvester",
+        "author": "Cam Barts (@cam-barts)",
+        "version": "1.0",
+        "description": "Harvests Basic Contact Information from Bing based on LinkedIn profiles",
+        "required_keys": ["bing_api"],
+        "comments": (
+            'Use Bing\'s top search results for LinkedIn urls to gather names, titles, and companies',
+            'This works for profiles that are set to public on LinkedIn'
+        ),
+        "query": "SELECT DISTINCT url FROM profiles WHERE resource='LinkedIn'",
+        "options": (),
+    }
+
+    def module_run(self, urls):
+        for url in urls:
+            self.get_contact_info(url)
+
+    def get_contact_info(self, url):
+        search_result = self.search_bing_api(url, 1)
+        if search_result and search_result[0]["url"] == url:
+            search_result = search_result[0]
+            link_title = search_result["name"]
+            name_and_title = link_title.split("|")[0]
+            name_title_company_list = name_and_title.split("-")
+            name = name_title_company_list[0].strip().split()
+            if "linkedin" not in name_title_company_list[-1].lower():
+                company = name_title_company_list[-1]
+            else:
+                company = False
+            if not company:
+                title = name_title_company_list[1]
+            else:
+                title = f"{name_title_company_list[1]} at {company}"
+            if len(name) > 2:
+                self.insert_contacts(
+                    first_name=name[0],
+                    middle_name=name[1],
+                    last_name=" ".join(name[2:]),
+                    title=title,
+                )
+            else:
+                self.insert_contacts(first_name=name[0], last_name=name[1], title=title)

--- a/modules/recon/profiles-contacts/bing_linkedin_contacts.py
+++ b/modules/recon/profiles-contacts/bing_linkedin_contacts.py
@@ -1,5 +1,6 @@
 from recon.core.module import BaseModule
 from recon.mixins.search import BingAPIMixin
+from recon.utils.parsers import parse_name
 
 
 class Module(BaseModule, BingAPIMixin):
@@ -11,8 +12,8 @@ class Module(BaseModule, BingAPIMixin):
         "description": "Harvests Basic Contact Information from Bing based on LinkedIn profiles",
         "required_keys": ["bing_api"],
         "comments": (
-            'Use Bing\'s top search results for LinkedIn urls to gather names, titles, and companies',
-            'This works for profiles that are set to public on LinkedIn'
+            "Use Bing's top search results for LinkedIn urls to gather names, titles, and companies",
+            "This works for profiles that are set to public on LinkedIn",
         ),
         "query": "SELECT DISTINCT url FROM profiles WHERE resource='LinkedIn'",
         "options": (),
@@ -24,26 +25,37 @@ class Module(BaseModule, BingAPIMixin):
 
     def get_contact_info(self, url):
         search_result = self.search_bing_api(url, 1)
+
+        # Search by url. If the url doesn't match, it has potential to be a different person
         if search_result and search_result[0]["url"] == url:
             search_result = search_result[0]
+            # "Name" is a misnomer, it actually refers to the link title
             link_title = search_result["name"]
+
+            # Split the title on the pipe to get rid of "linkedIn" portion at the end
             name_and_title = link_title.split("|")[0]
+            # Split whats left on the Dashes, which is usually name - title - company
             name_title_company_list = name_and_title.split("-")
-            name = name_title_company_list[0].strip().split()
+            # Parse out name
+            fullname = name_title_company_list[0]
+            fname, mname, lname = parse_name(fullname)
+
+            # Sometimes "LinkedIn" is left at the end anyway, and we don't want to confuse that for the company
             if "linkedin" not in name_title_company_list[-1].lower():
                 company = name_title_company_list[-1]
             else:
                 company = False
-            if not company:
-                title = name_title_company_list[1]
-            else:
-                title = f"{name_title_company_list[1]} at {company}"
-            if len(name) > 2:
+
+            # Try to parse out a title and company if it's there
+            if "linkedin" not in name_title_company_list[1].lower():
+                if not company:
+                    title = name_title_company_list[1]
+                else:
+                    title = f"{name_title_company_list[1]} at {company}"
                 self.insert_contacts(
-                    first_name=name[0],
-                    middle_name=name[1],
-                    last_name=" ".join(name[2:]),
-                    title=title,
+                    first_name=fname, middle_name=mname, last_name=lname, title=title
                 )
             else:
-                self.insert_contacts(first_name=name[0], last_name=name[1], title=title)
+                self.insert_contacts(
+                    first_name=fname, middle_name=mname, last_name=lname
+                )


### PR DESCRIPTION
Added a new module. This one is similar to the `bing_linkedin_cache` module, but a little bit simpler and useful for different situations. This gets companies and titles differently than `bing_linkedin_cache`, and is based on the contact's most recently updated LinkedIn position. This may give a better idea of who all in the contacts table still work at a certain company. This only grabs profiles that have privacy settings that allow bing to search them. 