### PR TITLE
viewdns.info reverse whois module

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -109,7 +109,7 @@
     free reverse whois tool.
   files: []
   last_updated: '2019-08-08'
-  name: viewdns.info reverse whois domain harvester
+  name: Viewdns Reverse Whois Domain Harvester
   path: recon/companies-domains/viewdns_reverse_whois
   required_keys: []
   version: '1.0'

--- a/modules.yml
+++ b/modules.yml
@@ -103,6 +103,16 @@
   path: recon/companies-domains/pen
   required_keys: []
   version: '1.0'
+- author: Gaetan Ferry (@_mabote_) from @synacktiv
+  dependencies: []
+  description: Harvests domain names belonging to a company by using the viewdns.info
+    free reverse whois tool.
+  files: []
+  last_updated: '2019-08-08'
+  name: viewdns.info reverse whois domain harvester
+  path: custom/companies-domains/viewdns_reverse_whois
+  required_keys: []
+  version: '1.0'
 - author: Tim Tomes (@lanmaster53)
   dependencies: []
   description: Uses the Github API to enumerate repositories and member profiles associated

--- a/modules.yml
+++ b/modules.yml
@@ -407,11 +407,11 @@
   description: Harvests hosts from Bing.com by using the 'site' search operator. Updates
     the 'hosts' table with the results.
   files: []
-  last_updated: '2019-06-24'
+  last_updated: '2019-07-04'
   name: Bing Hostname Enumerator
   path: recon/domains-hosts/bing_domain_web
   required_keys: []
-  version: '1.0'
+  version: '1.1'
 - author: Tim Tomes (@lanmaster53)
   dependencies: []
   description: Brute forces host names using DNS. Updates the 'hosts' table with the

--- a/modules.yml
+++ b/modules.yml
@@ -110,7 +110,7 @@
   files: []
   last_updated: '2019-08-08'
   name: viewdns.info reverse whois domain harvester
-  path: custom/companies-domains/viewdns_reverse_whois
+  path: recon/companies-domains/viewdns_reverse_whois
   required_keys: []
   version: '1.0'
 - author: Tim Tomes (@lanmaster53)

--- a/modules/recon/companies-domains/viewdns_reverse_whois.py
+++ b/modules/recon/companies-domains/viewdns_reverse_whois.py
@@ -1,0 +1,36 @@
+from recon.core.module import BaseModule
+from lxml.html import fromstring
+from urllib.parse import quote_plus
+
+class Module(BaseModule):
+
+	meta = {
+		'name': 'viewdns.info reverse whois domain harvester',
+		'author': 'Gaetan Ferry (@_mabote_) from @synacktiv',
+		'version': '1.0',
+		'description': 'Harvests domain names belonging to a company by using '
+					+  'the viewdns.info free reverse whois tool.',
+		'comments': ("Does not support company names < 6 characters",),
+		'query': 'SELECT DISTINCT company FROM companies WHERE company IS NOT NULL',
+	}
+
+	def module_run(self, companies):
+		base_url = "http://viewdns.info/reversewhois/"
+		for company in companies:
+			self.heading(company, level=0)
+			url = base_url + "?q=" + quote_plus(company)
+			resp = self.request("GET", url)
+			if resp.status_code != 200:
+				self.alert('An error occured: ' + str(resp.status_code))
+				continue
+			content = fromstring(resp.text)
+			domains = content.xpath("//table[@border='1']//tr/td[1]//text()")
+			# remove table headers
+			if len(domains) <= 0:
+				continue
+
+			domains = domains[1::]
+			for domain in domains:
+				self.insert_domains(domain)
+
+

--- a/modules/recon/companies-domains/viewdns_reverse_whois.py
+++ b/modules/recon/companies-domains/viewdns_reverse_whois.py
@@ -1,36 +1,35 @@
 from recon.core.module import BaseModule
 from lxml.html import fromstring
-from urllib.parse import quote_plus
+
 
 class Module(BaseModule):
 
-	meta = {
-		'name': 'viewdns.info reverse whois domain harvester',
-		'author': 'Gaetan Ferry (@_mabote_) from @synacktiv',
-		'version': '1.0',
-		'description': 'Harvests domain names belonging to a company by using '
-					+  'the viewdns.info free reverse whois tool.',
-		'comments': ("Does not support company names < 6 characters",),
-		'query': 'SELECT DISTINCT company FROM companies WHERE company IS NOT NULL',
-	}
+    meta = {
+        'name': 'Viewdns Reverse Whois Domain Harvester',
+        'author': 'Gaetan Ferry (@_mabote_) from @synacktiv',
+        'version': '1.0',
+        'description': 'Harvests domain names belonging to a company by using '
+            + 'the viewdns.info free reverse whois tool.',
+        'comments': (
+            'Does not support company names < 6 characters',
+        ),
+        'query': 'SELECT DISTINCT company FROM companies WHERE company IS NOT NULL',
+    }
 
-	def module_run(self, companies):
-		base_url = "http://viewdns.info/reversewhois/"
-		for company in companies:
-			self.heading(company, level=0)
-			url = base_url + "?q=" + quote_plus(company)
-			resp = self.request("GET", url)
-			if resp.status_code != 200:
-				self.alert('An error occured: ' + str(resp.status_code))
-				continue
-			content = fromstring(resp.text)
-			domains = content.xpath("//table[@border='1']//tr/td[1]//text()")
-			# remove table headers
-			if len(domains) <= 0:
-				continue
-
-			domains = domains[1::]
-			for domain in domains:
-				self.insert_domains(domain)
-
-
+    def module_run(self, companies):
+        url = 'http://viewdns.info/reversewhois/'
+        for company in companies:
+            self.heading(company, level=0)
+            payload = {'q': company}
+            resp = self.request('GET', url, params=payload)
+            if resp.status_code != 200:
+                self.alert('An error occured: ' + str(resp.status_code))
+                continue
+            content = fromstring(resp.text)
+            domains = content.xpath("//table[@border='1']//tr/td[1]//text()")
+            if len(domains) <= 0:
+                continue
+            # remove table headers
+            domains = domains[1::]
+            for domain in domains:
+                self.insert_domains(domain)

--- a/modules/recon/domains-hosts/bing_domain_web.py
+++ b/modules/recon/domains-hosts/bing_domain_web.py
@@ -10,7 +10,7 @@ class Module(BaseModule):
     meta = {
         'name': 'Bing Hostname Enumerator',
         'author': 'Tim Tomes (@lanmaster53)',
-        'version': '1.0',
+        'version': '1.1',
         'description': 'Harvests hosts from Bing.com by using the \'site\' search operator. Updates the \'hosts\' table with the results.',
         'query': 'SELECT DISTINCT domain FROM domains WHERE domain IS NOT NULL',
     }
@@ -37,7 +37,7 @@ class Module(BaseModule):
                 for sub in subs:
                     query += f" -domain:{sub}.{domain}"
                 full_query = base_query + query
-                url = f"{base_url}?first={page*nr}&q={urllib.parse.quote_plus(full_query)}"
+                url = f"{base_url}?first={page*nr}&q={quote_plus(full_query)}"
                 # bing errors out at > 2059 characters not including the protocol
                 if len(url) > 2066: url = url[:2066]
                 self.verbose(f"URL: {url}")


### PR DESCRIPTION
A new module using the viewdns.info application's reverse whois capabilities to collect domain names from a company name.