### PR TITLE
Fixed a display error in List File Importer

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -55,7 +55,7 @@
   name: List File Importer
   path: import/list
   required_keys: []
-  version: '1.0'
+  version: '1.1'
 - author: Ryan Hays (@_ryanhays)
   dependencies: []
   description: Imports hosts and ports into the respective databases from Masscan

--- a/modules/import/list.py
+++ b/modules/import/list.py
@@ -5,7 +5,7 @@ class Module(BaseModule):
     meta = {
         'name': 'List File Importer',
         'author': 'Tim Tomes (@lanmaster53)',
-        'version': '1.0',
+        'version': '1.1',
         'description': 'Imports values from a list file into a database table and column.',
         'options': (
             ('filename', None, True, 'path and filename for list input'),
@@ -20,7 +20,7 @@ class Module(BaseModule):
             lines = fh.read().split()
         method = 'insert_'+self.options['table'].lower()
         if not hasattr(self, method):
-            self.error(f"No such table: {options['table']}")
+            self.error(f"No such table: {self.options['table']}")
             return
         func = getattr(self, method)
         for line in lines:


### PR DESCRIPTION
* The "options" variable causes an error when the TABLE argument does not exist. 
The correct variable is "self.options".
* module version update 1.0 -> 1.1

**Before submitting a pull request, make sure to complete the following:**
- [x] Ensure there are no similar pull requests.
- [x] Read the [Development Guide](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide).

**What kind of PR is this?**  
_Please add an 'x' in the appropriate box, and apply a label to the PR matching the type here._
- [x] Bug Fix
- [ ] New Module
- [ ] Documentation Update

**Checklist For Approval**
- [x] Updated the meta dictionary for the module.
  - If bug fix, updated the version.
- [x] Indexed the module
- [x] Added the index to the `modules.yml` file
- [x] Made the most out of the available [mixins](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide#mixins).
- [x] Ensured the code is PEP8 compliant with `pycodestyle` or `black`.
