### PR TITLE
Add option to ignore forks; default false

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -128,12 +128,12 @@
   description: Uses the Github API to enumerate repositories and member profiles associated
     with a company search string. Updates the respective tables with the results.
   files: []
-  last_updated: '2019-06-24'
+  last_updated: '2020-05-15'
   name: Github Resource Miner
   path: recon/companies-multi/github_miner
   required_keys:
   - github_api
-  version: '1.0'
+  version: '1.1'
 - author: Austin Tipton (@hiEntropy404)
   dependencies: []
   description: Harvests host and port information from the Shodan API by using the
@@ -976,12 +976,12 @@
   description: Uses the Github API to enumerate repositories and gists owned by a
     Github user. Updates the 'repositories' table with the results.
   files: []
-  last_updated: '2019-06-24'
+  last_updated: '2020-05-15'
   name: Github Code Enumerator
   path: recon/profiles-repositories/github_repos
   required_keys:
   - github_api
-  version: '1.0'
+  version: '1.1'
 - author: Michael Henriksen (@michenriksen)
   dependencies: []
   description: Uses the Github API to gather user profiles from repository commits.

--- a/modules/recon/companies-multi/github_miner.py
+++ b/modules/recon/companies-multi/github_miner.py
@@ -10,6 +10,9 @@ class Module(BaseModule, GithubMixin):
         'description': 'Uses the Github API to enumerate repositories and member profiles associated with a company search string. Updates the respective tables with the results.',
         'required_keys': ['github_api'],
         'query': 'SELECT DISTINCT company FROM companies WHERE company IS NOT NULL',
+        'options': (
+            ('ignoreforks', False, False, 'ignore forks'),
+        ),
     }
 
     def module_run(self, companies):
@@ -29,12 +32,15 @@ class Module(BaseModule, GithubMixin):
             # enumerate repositories
             repos = self.query_github_api(f"/orgs/{quote_plus(company)}/repos")
             for repo in repos:
-                data = {
-                    'name': repo['name'],
-                    'owner': repo['owner']['login'],
-                    'description': repo['description'],
-                    'url': repo['html_url'],
-                    'resource': 'Github',
-                    'category': 'repo',
-                }
-                self.insert_repositories(**data)
+                if self.options['ignoreforks'] and repo['fork']:
+                    continue
+                else:
+                    data = {
+                        'name': repo['name'],
+                        'owner': repo['owner']['login'],
+                        'description': repo['description'],
+                        'url': repo['html_url'],
+                        'resource': 'Github',
+                        'category': 'repo',
+                    }
+                    self.insert_repositories(**data)

--- a/modules/recon/companies-multi/github_miner.py
+++ b/modules/recon/companies-multi/github_miner.py
@@ -6,12 +6,12 @@ class Module(BaseModule, GithubMixin):
     meta = {
         'name': 'Github Resource Miner',
         'author': 'Tim Tomes (@lanmaster53)',
-        'version': '1.0',
+        'version': '1.1',
         'description': 'Uses the Github API to enumerate repositories and member profiles associated with a company search string. Updates the respective tables with the results.',
         'required_keys': ['github_api'],
         'query': 'SELECT DISTINCT company FROM companies WHERE company IS NOT NULL',
         'options': (
-            ('ignoreforks', False, False, 'ignore forks'),
+            ('ignoreforks', True, True, 'ignore forks'),
         ),
     }
 
@@ -34,13 +34,12 @@ class Module(BaseModule, GithubMixin):
             for repo in repos:
                 if self.options['ignoreforks'] and repo['fork']:
                     continue
-                else:
-                    data = {
-                        'name': repo['name'],
-                        'owner': repo['owner']['login'],
-                        'description': repo['description'],
-                        'url': repo['html_url'],
-                        'resource': 'Github',
-                        'category': 'repo',
-                    }
-                    self.insert_repositories(**data)
+                data = {
+                    'name': repo['name'],
+                    'owner': repo['owner']['login'],
+                    'description': repo['description'],
+                    'url': repo['html_url'],
+                    'resource': 'Github',
+                    'category': 'repo',
+                }
+                self.insert_repositories(**data)

--- a/modules/recon/profiles-repositories/github_repos.py
+++ b/modules/recon/profiles-repositories/github_repos.py
@@ -6,7 +6,7 @@ class Module(BaseModule, GithubMixin):
     meta = {
         'name': 'Github Code Enumerator',
         'author': 'Tim Tomes (@lanmaster53)',
-        'version': '1.0',
+        'version': '1.1',
         'description': 'Uses the Github API to enumerate repositories and gists owned by a Github user. Updates the \'repositories\' table with the results.',
         'required_keys': ['github_api'],
         'query': "SELECT DISTINCT username FROM profiles WHERE username IS NOT NULL AND resource LIKE 'Github'",
@@ -23,16 +23,15 @@ class Module(BaseModule, GithubMixin):
             for repo in repos:
                 if self.options['ignoreforks'] and repo['fork']:
                     continue
-                else:
-                    data = {
-                        'name': repo['name'],
-                        'owner': repo['owner']['login'],
-                        'description': repo['description'],
-                        'url': repo['html_url'],
-                        'resource': 'Github',
-                        'category': 'repo',
-                    }
-                    self.insert_repositories(**data)
+                data = {
+                    'name': repo['name'],
+                    'owner': repo['owner']['login'],
+                    'description': repo['description'],
+                    'url': repo['html_url'],
+                    'resource': 'Github',
+                    'category': 'repo',
+                }
+                self.insert_repositories(**data)
             # enumerate gists
             gists = self.query_github_api(f"/users/{quote_plus(user)}/gists")
             for gist in gists:


### PR DESCRIPTION
Adds a new option to github modules to ignore adding forks to the repository db. Defaults to false. This can be useful as it can be easy to go down a path of enumerating contributers to those parent projects and thus end up in a large tragectory away from the original recon subject.

New option:

```
  Name         Current Value  Required  Description
  -----------  -------------  --------  -----------
  IGNOREFORKS  False          no        ignore forks
```

**Before submitting a pull request, make sure to complete the following:**
- [x] Ensure there are no similar pull requests.
- [x] Read the [Development Guide](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide).

**What kind of PR is this?**  
_Please add an 'x' in the appropriate box, and apply a label to the PR matching the type here._
- [x] Bug Fix (not really, more like an extension of the module)
- [ ] New Module
- [ ] Documentation Update

**Checklist For Approval**
- [x] Updated the meta dictionary for the module.
  - If bug fix, updated the version.
- [ ] Indexed the module
- [ ] Added the index to the `modules.yml` file
- [x] Made the most out of the available [mixins](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide#mixins).
- [x] Ensured the code is PEP8 compliant with `pycodestyle` or `black`.
