### PR TITLE
Fix for 404 on Whoxy_whois

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -380,7 +380,7 @@
   files: []
   last_updated: '2020-06-17'
   name: Whoxy Whois Lookup
-  path: recon/domains-companies/whoxy_whois
+  path: recon/domains-companies/whoxy_companies
   required_keys:
   - whoxy_api
   version: '1.0'


### PR DESCRIPTION
"marketplace install all" fails at whoxy_whois with the error:
[!] Module installation failed: recon/domains-companies/whoxy_whois.
[!] Invalid response from module repository (404)
The path in the modules directory suggests this should be whoxy_companies as that maps to the python file at https://github.com/lanmaster53/recon-ng-marketplace/blob/master/modules/recon/domains-companies/whoxy_companies.py
whereas whoxy_whois does not.

**Before submitting a pull request, make sure to complete the following:**
- [ ] Ensure there are no similar pull requests.
- [ ] Read the [Development Guide](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide).

**What kind of PR is this?**  
_Please add an 'x' in the appropriate box, and apply a label to the PR matching the type here._
- [x] Bug Fix
- [ ] New Module
- [ ] Documentation Update

**Checklist For Approval**
- [x] Updated the meta dictionary for the module.
  - If bug fix, updated the version.
- [ ] Indexed the module
- [ ] Added the index to the `modules.yml` file
- [ ] Made the most out of the available [mixins](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide#mixins).
- [ ] Ensured the code is PEP8 compliant with `pycodestyle` or `black`.
