### PR TITLE
Fix in Modules.yml with shodan pushpin. 

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -920,10 +920,9 @@
 - author: Tim Tomes (@lanmaster53) & Ryan Hays (@_ryanhays)
   dependencies:
   - shodan
-  dependencies: []
   description: Searches Shodan for media in the specified proximity to a location.
   files: []
-  last_updated: '2020-07-01'
+  last_updated: '2020-07-07'
   name: Shodan Geolocation Search
   path: recon/locations-pushpins/shodan
   required_keys:


### PR DESCRIPTION
**Before submitting a pull request, make sure to complete the following:**
- [X] Ensure there are no similar pull requests.
- [X] Read the [Development Guide](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide).

**What kind of PR is this?**  
_Please add an 'x' in the appropriate box, and apply a label to the PR matching the type here._
- [x] Bug Fix
- [ ] New Module
- [ ] Documentation Update

**Checklist For Approval**
- [x] Updated the meta dictionary for the module.
  - If bug fix, updated the version.
- [x] Indexed the module
- [ ] Added the index to the `modules.yml` file
- [ ] Made the most out of the available [mixins](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide#mixins).
- [ ] Ensured the code is PEP8 compliant with `pycodestyle` or `black`.


Using the new index script I found an error in the modules.yml with recon/locations-pushpins/shodan module. It had duplicate dependencies. Fixed here. 