### PR TITLE
Fix cache_snoop dnspython imports

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -3,11 +3,11 @@
   description: Uses the DNS cache snooping technique to check for visited domains
   files:
   - av_domains.lst
-  last_updated: '2019-06-24'
+  last_updated: '2020-10-13'
   name: DNS Cache Snooper
   path: discovery/info_disclosure/cache_snoop
   required_keys: []
-  version: '1.0'
+  version: '1.1'
 - author: Tim Tomes (@lanmaster53), thrapt (thrapt@gmail.com), Jay Turla (@shipcod3),
     and Mark Jeffery
   dependencies: []

--- a/modules/discovery/info_disclosure/cache_snoop.py
+++ b/modules/discovery/info_disclosure/cache_snoop.py
@@ -1,6 +1,7 @@
 from recon.core.module import BaseModule
 import os
-import dns
+import dns.message
+import dns.query
 import re
 
 class Module(BaseModule):

--- a/modules/discovery/info_disclosure/cache_snoop.py
+++ b/modules/discovery/info_disclosure/cache_snoop.py
@@ -10,7 +10,7 @@ class Module(BaseModule):
     meta = {
         'name': 'DNS Cache Snooper',
         'author': 'thrapt (thrapt@gmail.com)',
-        'version': '1.0',
+        'version': '1.1',
         'description': 'Uses the DNS cache snooping technique to check for visited domains',
         'comments': (
             'Nameserver must be in IP form.',

--- a/modules/discovery/info_disclosure/cache_snoop.py
+++ b/modules/discovery/info_disclosure/cache_snoop.py
@@ -4,6 +4,7 @@ import dns.message
 import dns.query
 import re
 
+
 class Module(BaseModule):
 
     meta = {
@@ -30,7 +31,7 @@ class Module(BaseModule):
             response = None
             # prepare our query
             query = dns.message.make_query(domain, dns.rdatatype.A, dns.rdataclass.IN)
-            # unset the Recurse flag 
+            # unset the Recurse flag
             query.flags ^= dns.flags.RD
             response = dns.query.udp(query, nameserver)
             if len(response.answer) > 0:


### PR DESCRIPTION
Fixed cache_snoop dnspython imports to prevent "Module 'dns' has no attribute...." issue by explicitly importing the utilized dnspython submodules (i.e. dns.message and dns.query).
**Before submitting a pull request, make sure to complete the following:**
- [x] Ensure there are no similar pull requests.
- [x] Read the [Development Guide](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide).

**What kind of PR is this?**  
_Please add an 'x' in the appropriate box, and apply a label to the PR matching the type here._
- [x] Bug Fix
- [ ] New Module
- [ ] Documentation Update

**Checklist For Approval**
- [x] Updated the meta dictionary for the module.
  - If bug fix, updated the version.
- [ ] Indexed the module
- [x] Added the index to the `modules.yml` file
- [ ] Made the most out of the available [mixins](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide#mixins).
- [x] Ensured the code is PEP8 compliant with `pycodestyle` or `black`.
