### PR TITLE
Fix XSSed false positive bug

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -729,11 +729,11 @@
   description: Checks XSSed.com for XSS records associated with a domain and displays
     the first 20 results.
   files: []
-  last_updated: '2019-06-24'
+  last_updated: '2020-10-18'
   name: XSSed Domain Lookup
   path: recon/domains-vulnerabilities/xssed
   required_keys: []
-  version: '1.0'
+  version: '1.1'
 - author: Tim Tomes (@lanmaster53)
   dependencies: []
   description: Adds a new domain for all the hostnames stored in the 'hosts' table.

--- a/modules/recon/domains-vulnerabilities/xssed.py
+++ b/modules/recon/domains-vulnerabilities/xssed.py
@@ -8,7 +8,7 @@ class Module(BaseModule):
     meta = {
         'name': 'XSSed Domain Lookup',
         'author': 'Micah Hoffman (@WebBreacher)',
-        'version': '1.0',
+        'version': '1.1',
         'description': 'Checks XSSed.com for XSS records associated with a domain and displays the first 20 results.',
         'query': 'SELECT DISTINCT domain FROM domains WHERE domain IS NOT NULL',
     }
@@ -26,6 +26,8 @@ class Module(BaseModule):
                 # Parse the response and get the details
                 details = re.findall(r'<th class="row3"[^>]*>[^:?]+[:?]+(.+?)<\/th>', resp_vuln.text)#.replace('&nbsp;', ' '))
                 details = [self.html_unescape(x).strip() for x in details]
+                if not re.match(rf"(^|.*\.){re.escape(domain)}$", details[5], re.IGNORECASE):
+                    continue
                 data = {}
                 data['host'] = details[5]
                 data['reference'] = url_vuln % vuln


### PR DESCRIPTION
Currently the `xssed` module will return false positives - as an example searching for `bbc.com` might return `mybbc.com`.  this pr adds a regex check on the host to ensure that the pattern matches with the domain only, or a subdomain of the domain.

**What kind of PR is this?**  
_Please add an 'x' in the appropriate box, and apply a label to the PR matching the type here._
- [x ] Bug Fix
- [ ] New Module
- [ ] Documentation Update

**Checklist For Approval**
- [x ] Updated the meta dictionary for the module.
  - If bug fix, updated the version.
- [x] Indexed the module
- [x] Added the index to the `modules.yml` file
- [x] Made the most out of the available [mixins](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide#mixins).
- [x] Ensured the code is PEP8 compliant with `pycodestyle` or `black`.
