### PR TITLE
Bugfix for recon/contacts-credentials/scylla. Email/Start

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -286,11 +286,11 @@
   description: Harvests credentials from the scylla.sh API using email addresses as
     input. Updates the 'credentials' and 'contacts' tables with the results.
   files: []
-  last_updated: '2020-09-14'
+  last_updated: '2021-01-24'
   name: Scylla Targetted Credential Harvester
   path: recon/contacts-credentials/scylla
   required_keys: []
-  version: '1.3'
+  version: '1.4'
 - author: Tim Tomes (@lanmaster53)
   dependencies: []
   description: Adds a new domain for all the hostnames associated with email addresses

--- a/modules/recon/contacts-credentials/scylla.py
+++ b/modules/recon/contacts-credentials/scylla.py
@@ -8,7 +8,7 @@ class Module(BaseModule):
     meta = {
         'name': 'Scylla Targetted Credential Harvester',
         'author': 'Tim Tomes (@lanmaster53)',
-        'version': '1.3',
+        'version': '1.4',
         'description': 'Harvests credentials from the scylla.sh API using email addresses as input. Updates the '
                        '\'credentials\' and \'contacts\' tables with the results.',
         'options': (
@@ -21,10 +21,10 @@ class Module(BaseModule):
         base_url = 'https://scylla.sh/search'
         headers = {'Accept': 'application/json'}
         size = self.options['size']
-        start = 1
+        start = 0
         for email in emails:
             while True:
-                payload = {'q': f"Email:\"{email}\"", 'size': size, 'start': start}
+                payload = {'q': f"email:\"{email}\"", 'size': size, 'start': start}
                 resp = self.request('GET', base_url, params=payload, headers=headers, auth=('sammy', 'BasicPassword!'))
                 if resp.status_code != 200:
                     self.error('Invalid response.')


### PR DESCRIPTION
Fix1:
'Email' is case sensitive and only works with lower case.
Fix2:
The start also starts with 0, instead of 1.  This fixes missing the first result being skipped.

**Before submitting a pull request, make sure to complete the following:**
- [x] Ensure there are no similar pull requests.
- [x] Read the [Development Guide](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide).

**What kind of PR is this?**  
_Please add an 'x' in the appropriate box, and apply a label to the PR matching the type here._
- [x] Bug Fix
- [ ] New Module
- [ ] Documentation Update

**Checklist For Approval**
- [x] Updated the meta dictionary for the module.
  - If bug fix, updated the version.
- [n/a] Indexed the module (N/A - bugfix)
- [n/a] Added the index to the `modules.yml` file (N/A - bugfix)
- [n/a] Made the most out of the available [mixins](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide#mixins). (N/A - bugfix)
- [n/a] Ensured the code is PEP8 compliant with `pycodestyle` or `black`. (N/A - bugfix, no syntax changes)
