### PR TITLE
Utilize better parser for ssl_scan and remove arcane regex

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -1054,11 +1054,11 @@
     connects to each service updating the Ports table with the certificate common
     name and then adds the Subject Alt Names to the hosts table.
   files: []
-  last_updated: '2020-04-13'
+  last_updated: '2021-02-15'
   name: SSL Scanner SAN Lookup
   path: recon/ports-hosts/ssl_scan
   required_keys: []
-  version: '1.0'
+  version: '1.1'
 - author: Cam Barts (@cam-barts)
   dependencies: []
   description: Harvests Basic Contact Information from Bing based on LinkedIn profiles.

--- a/modules.yml
+++ b/modules.yml
@@ -1054,7 +1054,7 @@
     connects to each service updating the Ports table with the certificate common
     name and then adds the Subject Alt Names to the hosts table.
   files: []
-  last_updated: '2021-02-15'
+  last_updated: '2021-08-24'
   name: SSL Scanner SAN Lookup
   path: recon/ports-hosts/ssl_scan
   required_keys: []


### PR DESCRIPTION
Moving to the `cryptography` library gives us better x509 parsing than
regex and M2Crypto, plus it removes the need for swig to install it.

**Before submitting a pull request, make sure to complete the following:**
- [x] Ensure there are no similar pull requests.
- [x] Read the [Development Guide](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide).

**What kind of PR is this?**  
_Please add an 'x' in the appropriate box, and apply a label to the PR matching the type here._
- [x] Bug Fix
- [ ] New Module
- [ ] Documentation Update

**Checklist For Approval**
- [x] Updated the meta dictionary for the module.
  - If bug fix, updated the version.
- [x] Indexed the module
- [x] Added the index to the `modules.yml` file
- [x] Made the most out of the available [mixins](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide#mixins).
- [x] Ensured the code is PEP8 compliant with `pycodestyle` or `black`.
