### PR TITLE
Support custom filenames with CSV file for interesting_files module

### DIFF
--- a/data/interesting_files_verify.csv
+++ b/data/interesting_files_verify.csv
@@ -1,0 +1,11 @@
+robots.txt,user-agent:
+sitemap.xml,<?xml
+sitemap.xml.gz,<?xml
+crossdomain.xml,<?xml
+phpinfo.php,phpinfo()
+test.php,phpinfo()
+elmah.axd,Error Log for
+server-status,>Apache Status<
+jmx-console/,JBoss
+admin-console/,index.seam
+web-console/,Administration

--- a/modules.yml
+++ b/modules.yml
@@ -13,11 +13,11 @@
   dependencies: []
   description: Checks hosts for interesting files in predictable locations.
   files: []
-  last_updated: '2020-01-13'
+  last_updated: '2021-10-02'
   name: Interesting File Finder
   path: discovery/info_disclosure/interesting_files
   required_keys: []
-  version: '1.1'
+  version: '1.2'
 - author: Tim Tomes (@lanmaster53)
   dependencies: []
   description: Provides a shell interface for remote command injection flaws in web

--- a/modules.yml
+++ b/modules.yml
@@ -12,8 +12,9 @@
     and Mark Jeffery
   dependencies: []
   description: Checks hosts for interesting files in predictable locations.
-  files: []
-  last_updated: '2021-10-02'
+  files:
+  - interesting_files_verify.csv
+  last_updated: '2021-10-04'
   name: Interesting File Finder
   path: discovery/info_disclosure/interesting_files
   required_keys: []

--- a/modules/discovery/info_disclosure/interesting_files.py
+++ b/modules/discovery/info_disclosure/interesting_files.py
@@ -8,7 +8,7 @@ class Module(BaseModule):
     meta = {
         'name': 'Interesting File Finder',
         'author': 'Tim Tomes (@lanmaster53), thrapt (thrapt@gmail.com), Jay Turla (@shipcod3), and Mark Jeffery',
-        'version': '1.1',
+        'version': '1.2',
         'description': 'Checks hosts for interesting files in predictable locations.',
         'comments': (
             'Files: robots.txt, sitemap.xml, sitemap.xml.gz, crossdomain.xml, phpinfo.php, test.php, elmah.axd, server-status, jmx-console/, admin-console/, web-console/',
@@ -60,7 +60,8 @@ class Module(BaseModule):
         count = 0
         for host in hosts:
             if self.options['files']:
-                filetypes = [(fname, False) for fname in self.options['files'].split()]
+                filenames = self.options['files'].split()
+                filetypes = [(fname, False) for fname in filenames]
 
             for (filename, verify) in filetypes:
                 url = f"{protocol}://{host}:{port}/{filename}"

--- a/modules/discovery/info_disclosure/interesting_files.py
+++ b/modules/discovery/info_disclosure/interesting_files.py
@@ -20,6 +20,7 @@ class Module(BaseModule):
         'query': 'SELECT DISTINCT host FROM hosts WHERE host IS NOT NULL',
         'options': (
             ('download', True, True, 'download discovered files'),
+            ('files', None, False, 'override files to search'),
             ('protocol', 'http', True, 'request protocol'),
             ('port', 80, True, 'request port'),
         ),
@@ -58,6 +59,9 @@ class Module(BaseModule):
         ]
         count = 0
         for host in hosts:
+            if self.options['files']:
+                filetypes = [(fname, False) for fname in self.options['files'].split()]
+
             for (filename, verify) in filetypes:
                 url = f"{protocol}://{host}:{port}/{filename}"
                 try:
@@ -71,7 +75,7 @@ class Module(BaseModule):
                     # uncompress if necessary
                     text = ('.gz' in filename and self.uncompress(resp.text)) or resp.text
                     # check for file type since many custom 404s are returned as 200s
-                    if verify.lower() in text.lower():
+                    if verify and verify.lower() in text.lower():
                         self.alert(f"{url} => {code}. '{filename}' found!")
                         # urls that end with '/' are not necessary to download
                         if download and not filename.endswith("/"):

--- a/modules/discovery/info_disclosure/interesting_files.py
+++ b/modules/discovery/info_disclosure/interesting_files.py
@@ -35,6 +35,8 @@ class Module(BaseModule):
     def read_filenames_csv(self):
         with open(os.path.expanduser(self.options['csv_file'])) as csvfile:
             fname_csv = csv.reader(csvfile, delimiter=',', quotechar='"')
+            # verification string used to prevent false positives;
+            #   eg: if robots.txt redirects to login page & returns a 200
             return [(fname, verify_str) for (fname, verify_str) in fname_csv]
 
     def uncompress(self, data_gz):
@@ -54,11 +56,9 @@ class Module(BaseModule):
         port = self.options['port']
         # ignore unicode warnings when trying to un-gzip text type 200 repsonses
         warnings.simplefilter("ignore")
-        # (filename, string to search for to prevent false positive)
-
         filetypes = self.read_filenames_csv()
-
         count = 0
+
         for host in hosts:
             for (filename, verify) in filetypes:
                 url = f"{protocol}://{host}:{port}/{filename}"


### PR DESCRIPTION
Simple addition to allow files to be overridden.  This has two benefits:
* more efficient if just looking for a smaller subset of files (eg: just robots.txt)
* more flexible to allow for custom file searches

Changes are pretty straightforward, but this is my first attempt at a recon-ng contribution, so any feedback is very welcome.  I believe I should have everything set properly in terms of indexing, but sincere apologies if I missed anything there

**Before submitting a pull request, make sure to complete the following:**
- [x] Ensure there are no similar pull requests.
- [x] Read the [Development Guide](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide).

**What kind of PR is this?**  
_Please add an 'x' in the appropriate box, and apply a label to the PR matching the type here._
- [ ] Bug Fix
- [ ] New Module
- [ ] Documentation Update
- [x] New Feature for existing module

**Checklist For Approval**
- [x] Updated the meta dictionary for the module.
  - If bug fix, updated the version.
- [x] Indexed the module
- [x] Added the index to the `modules.yml` file
- [x] Made the most out of the available [mixins](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide#mixins).
- [x] Ensured the code is PEP8 compliant with `pycodestyle` or `black`.
