### PR TITLE
Add module hackertarget_reverse (HackerTarget.com reverse IP lookup API)

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -1250,3 +1250,13 @@
   path: reporting/xml
   required_keys: []
   version: '1.1'
+- author: Qazeer
+  dependencies: []
+  description: Uses the HackerTarget.com reverse IP lookup API to find host names
+    associated with IP addresses. Updates the 'hosts' table with the results.
+  files: []
+  last_updated: '2021-10-03'
+  name: HackerTarget reverse IP lookup
+  path: recon/hosts-hosts/hackertarget_reverse
+  required_keys: []
+  version: '1.0'

--- a/modules/recon/hosts-hosts/hackertarget_reverse.py
+++ b/modules/recon/hosts-hosts/hackertarget_reverse.py
@@ -1,0 +1,36 @@
+from recon.core.module import BaseModule
+
+
+class Module(BaseModule):
+    meta = {
+        'name': 'HackerTarget reverse IP lookup',
+        'author': 'Qazeer',
+        'version': '1.0',
+        'description': 'Uses the HackerTarget.com reverse IP lookup API to find host names associated with IP addresses. Updates the \'hosts\' table with the results.',
+        'query': 'SELECT DISTINCT ip_address FROM hosts WHERE ip_address IS NOT NULL',
+    }
+
+    def module_run(self, hosts):
+        for ip in hosts:
+            self.heading(ip, level=0)
+            url = 'https://api.hackertarget.com/reverseiplookup/'
+            payload = {'q': ip}
+            resp = self.request('GET', url, params=payload)
+            if resp.status_code != 200:
+                self.error(f"Got unexpected response code: {resp.status_code}")
+                continue
+            if resp.text == '' or 'No DNS A records found' in resp.text:
+                self.output('No results found.')
+                continue
+            if resp.text.startswith('error'):
+                self.error(resp.text)
+                continue
+            if 'API count exceeded' in resp.text:
+                self.error(resp.text)
+                continue
+            for line in resp.text.split("\n"):
+                line = line.strip()
+                if line == '':
+                    continue
+                new_host = line.split(",")
+                self.insert_hosts(host=new_host, ip_address=ip)


### PR DESCRIPTION
**Before submitting a pull request, make sure to complete the following:**
- [x] Ensure there are no similar pull requests.
- [x] Read the [Development Guide](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide).

**What kind of PR is this?**  
- [ ] Bug Fix
- [x] New Module
- [ ] Documentation Update

**Checklist For Approval**
- [ ] Updated the meta dictionary for the module.
  - If bug fix, updated the version.
- [x] Indexed the module
- [x] Added the index to the `modules.yml` file
- [ ] Made the most out of the available [mixins](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide#mixins).
- [x] Ensured the code is PEP8 compliant with `pycodestyle` or `black`.

---

Remark: the API limit for the free tier is 20 requests per day. If the limit is reached, the API returns "API count exceeded" which raise an error.