### PR TITLE
Support for uri_pretty in the profiles-profiles/profiler.py

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -1098,11 +1098,11 @@
     of web sites for those users. The list of valid sites comes from the parent project
     at https://github.com/WebBreacher/WhatsMyName
   files: []
-  last_updated: '2019-10-16'
+  last_updated: '2023-02-05'
   name: OSINT HUMINT Profile Collector
   path: recon/profiles-profiles/profiler
   required_keys: []
-  version: '1.1'
+  version: '1.2'
 - author: Robert Frost (@frosty_1313, frosty[at]unluckyfrosty.net)
   dependencies: []
   description: Leverages the Twitter API to enumerate users that mentioned the given

--- a/modules/recon/profiles-profiles/profiler.py
+++ b/modules/recon/profiles-profiles/profiler.py
@@ -7,7 +7,7 @@ class Module(BaseModule, ThreadingMixin):
     meta = {
         'name': 'OSINT HUMINT Profile Collector',
         'author': 'Micah Hoffman (@WebBreacher), Brendan Burke (@gbinv)',
-        'version': '1.1',
+        'version': '1.2',
         'description': 'Takes each username from the profiles table and searches a variety of web sites for those users. The list of valid sites comes from the parent project at https://github.com/WebBreacher/WhatsMyName',
         'comments': (
             'Note: The global timeout option may need to be increased to support slower sites.',
@@ -34,7 +34,12 @@ class Module(BaseModule, ThreadingMixin):
             if resp.status_code == int(d['e_code']):
                 self.debug(f"Codes matched {resp.status_code} {d['e_code']}")
                 if d['e_string'] in resp.text or d['e_string'] in resp.headers:
-                    self.insert_profiles(username=user, url=url, resource=d['name'], category=d['cat'])
+                    pretty_url = self._pretty_uri(site, user)
+                    self.insert_profiles(username=user, url=pretty_url, resource=d['name'], category=d['cat'])
                     self.query('DELETE FROM profiles WHERE username = ? and url IS NULL', (user,))
 
+    def _pretty_uri(self, site, user):
+        """Return pretty URI for displaying result (in case if API was used to check account)"""
+        pretty_uri_key = 'uri_pretty' if 'uri_pretty' in site else 'uri_check'
+        return site[pretty_uri_key].replace('{account}', user)
 


### PR DESCRIPTION
**Before submitting a pull request, make sure to complete the following:**
- [x] Ensure there are no similar pull requests.
- [x] Read the [Development Guide](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide).

**What kind of PR is this?**  
_Please add an 'x' in the appropriate box, and apply a label to the PR matching the type here._
- [x] Bug Fix
- [ ] New Module
- [ ] Documentation Update

**Checklist For Approval**
- [x] Updated the meta dictionary for the module.
  - [x] If bug fix, updated the version.
- [x] Indexed the module
- [ ] Added the index to the `modules.yml` file
- [x] Made the most out of the available [mixins](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide#mixins).
- [ ] Ensured the code is PEP8 compliant with `pycodestyle` or `black`.  (partly, only new code)

**Task**
This PR adds support for `uri_pretty` in WhatsMyName sources list. 

Some checks there uses API calls, or calls to some archives to actually check username. In this case there are `uri_pretty` field, which shows normal human readable URI to the profile.

**Example.**

Before:
```
  https://www.duolingo.com/2017-06-30/users?username=khaby.lame&_=1628308619574
  https://feelinsonice.appspot.com/web/deeplink/snapcode?username=khaby.lame&size=400&type=SVG
  https://www.tiktok.com/oembed?url=https://www.tiktok.com/@khaby.lame
```

After:
```
https://www.duolingo.com/profile/khaby.lame
https://www.snapchat.com/add/khaby.lame
https://www.tiktok.com/@khaby.lame?lang=en
```

