### PR TITLE
Certificate transparency add header

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -608,7 +608,7 @@
   name: Certificate Transparency Search
   path: recon/domains-hosts/certificate_transparency
   required_keys: []
-  version: '1.2'
+  version: '1.3'
 - author: Tim Tomes (@lanmaster53)
   dependencies: []
   description: Harvests hosts from Google.com by using the 'site' search operator.

--- a/modules/recon/domains-hosts/certificate_transparency.py
+++ b/modules/recon/domains-hosts/certificate_transparency.py
@@ -7,7 +7,7 @@ class Module(BaseModule):
     meta = {
         'name': 'Certificate Transparency Search',
         'author': 'Rich Warren (richard.warren@nccgroup.trust)',
-        'version': '1.2',
+        'version': '1.3',
         'description': 'Searches certificate transparency data from crt.sh, adding newly identified hosts to the hosts '
                        'table.',
         'comments': (
@@ -19,7 +19,11 @@ class Module(BaseModule):
     def module_run(self, domains):
         for domain in domains:
             self.heading(domain, level=0)
-            resp = self.request('GET', f"https://crt.sh/?q=%25.{domain}&output=json")
+            resp = self.request(
+                'GET',
+                f"https://crt.sh/?q=%25.{domain}&output=json",
+                headers={"Accept": "application/json"},
+            )
             
             if resp.status_code != 200:
                 self.output(f"Invalid response for '{domain}'")


### PR DESCRIPTION
I was having issues with crt.sh returning and SQL error when I was using the default accept header `*/*`, but when I added this it wasn't happening anymore.

Of course now I can't reproduce it, since I'm submitting a PR for it :face_exhaling:, but since this module is accepting JSON back anyway I figure it doesn't hurt to add the header.

**Before submitting a pull request, make sure to complete the following:**
- [x] Ensure there are no similar pull requests.
- [x] Read the [Development Guide](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide).

**What kind of PR is this?**  
_Please add an 'x' in the appropriate box, and apply a label to the PR matching the type here._
- [x] Bug Fix
- [ ] New Module
- [ ] Documentation Update

**Checklist For Approval**
- [x] Updated the meta dictionary for the module.
  - [x] If bug fix, updated the version.
- [x] Indexed the module
- [x] Added the index to the `modules.yml` file
- [x] Made the most out of the available [mixins](https://github.com/lanmaster53/recon-ng/wiki/Development-Guide#mixins).
- [ ] Ensured the code is PEP8 compliant with `pycodestyle` or `black`.
   - technically I didn't run it on the file (since I did it all in the web-ui), but I pretty much copy/pasted from a local version which I had run `black` on.